### PR TITLE
Fix truncated index.html

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM nginx
 COPY build /usr/share/nginx/html
 COPY proxy.template /etc/nginx/conf.d/proxy.template
 ENV VIDISPINE_URL=http://localhost:8080
-CMD ["/bin/bash", "-c", "envsubst < /etc/nginx/conf.d/proxy.template > /etc/nginx/conf.d/default.conf && envsubst < /usr/share/nginx/html/index.html > /usr/share/nginx/html/index.html && nginx -g 'daemon off;'"]
+CMD ["/bin/bash", "-c", "envsubst < /etc/nginx/conf.d/proxy.template > /etc/nginx/conf.d/default.conf && envsubst < /usr/share/nginx/html/index.html > /tmp/_index.html && mv -f /tmp/_index.html /usr/share/nginx/html/index.html && nginx -g 'daemon off;'"]


### PR DESCRIPTION
This command truncates index.html when we run the docker container on our internal test server:
`envsubst < /usr/share/nginx/html/index.html > /usr/share/nginx/html/index.html`

Changed it to:
`envsubst < /usr/share/nginx/html/index.html > /tmp/_index.html && mv -f /tmp/_index.html /usr/share/nginx/html/index.html`